### PR TITLE
Remove legacy libraries from models

### DIFF
--- a/minitwit_csharp/minitwit/Api/Controllers/MinitwitApi.cs
+++ b/minitwit_csharp/minitwit/Api/Controllers/MinitwitApi.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 // using Swashbuckle.AspNetCore.Annotations;
 // using Swashbuckle.AspNetCore.SwaggerGen;
-
 using System.Text.Json;
 using Org.OpenAPITools.Attributes;
 using Org.OpenAPITools.Models;
@@ -78,9 +77,9 @@ namespace Org.OpenAPITools.Controllers
         [HttpGet]
         [Route("/latest")]
         [ValidateModelState]
-        [SwaggerOperation("GetLatestValue")]
-        [SwaggerResponse(statusCode: 200, type: typeof(LatestValue), description: "Success")]
-        [SwaggerResponse(statusCode: 500, type: typeof(ErrorResponse), description: "Internal Server Error")]
+        [EndpointSummary("GetLatestValue")]
+        [ProducesResponseType(statusCode: 200, type: typeof(LatestValue), Description ="Success")]
+        [ProducesResponseType(statusCode: 500, type: typeof(ErrorResponse), Description= "Internal Server Error")]
         public virtual IActionResult GetLatestValue()
         {
 
@@ -111,9 +110,9 @@ namespace Org.OpenAPITools.Controllers
         [HttpGet]
         [Route("/msgs")]
         [ValidateModelState]
-        [SwaggerOperation("GetMessages")]
-        [SwaggerResponse(statusCode: 200, type: typeof(List<Message>), description: "Success")]
-        [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
+        [EndpointSummary("GetMessages")]
+        [ProducesResponseType(statusCode: 200, type: typeof(List<Message>), Description= "Success")]
+        [ProducesResponseType(statusCode: 403, type: typeof(ErrorResponse), Description= "Unauthorized - Must include correct Authorization header")]
         public virtual IActionResult GetMessages([FromHeader (Name = "Authorization")][Required()]string authorization, [FromQuery (Name = "latest")]int? latest, [FromQuery (Name = "no")]int? no)
         {
 
@@ -146,9 +145,9 @@ namespace Org.OpenAPITools.Controllers
         [HttpGet]
         [Route("/msgs/{username}")]
         [ValidateModelState]
-        [SwaggerOperation("GetMessagesPerUser")]
-        [SwaggerResponse(statusCode: 200, type: typeof(List<Message>), description: "Success")]
-        [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
+        [EndpointSummary("GetMessagesPerUser")]
+        [ProducesResponseType(statusCode: 200, type: typeof(List<Message>), Description= "Success")]
+        [ProducesResponseType(statusCode: 403, type: typeof(ErrorResponse), Description= "Unauthorized - Must include correct Authorization header")]
         public virtual IActionResult GetMessagesPerUser([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromQuery (Name = "latest")]int? latest, [FromQuery (Name = "no")]int? no)
         {
 
@@ -184,8 +183,8 @@ namespace Org.OpenAPITools.Controllers
         [Route("/fllws/{username}")]
         [Consumes("application/json")]
         [ValidateModelState]
-        [SwaggerOperation("PostFollow")]
-        [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
+        [EndpointSummary("PostFollow")]
+        [ProducesResponseType(statusCode: 403, type: typeof(ErrorResponse), Description= "Unauthorized - Must include correct Authorization header")]
         public virtual IActionResult PostFollow([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromBody]FollowAction payload, [FromQuery (Name = "latest")]int? latest)
         {
 
@@ -213,8 +212,8 @@ namespace Org.OpenAPITools.Controllers
         [Route("/msgs/{username}")]
         [Consumes("application/json")]
         [ValidateModelState]
-        [SwaggerOperation("PostMessagesPerUser")]
-        [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
+        [EndpointSummary("PostMessagesPerUser")]
+        [ProducesResponseType(statusCode: 403, type: typeof(ErrorResponse), Description ="Unauthorized - Must include correct Authorization header")]
         public virtual IActionResult PostMessagesPerUser([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromBody]PostMessage payload, [FromQuery (Name = "latest")]int? latest)
         {
 
@@ -238,8 +237,8 @@ namespace Org.OpenAPITools.Controllers
         [Route("/register")]
         [Consumes("application/json")]
         [ValidateModelState]
-        [SwaggerOperation("PostRegister")]
-        [SwaggerResponse(statusCode: 400, type: typeof(ErrorResponse), description: "Bad Request | Possible reasons:  - missing username  - invalid email  - password missing  - username already taken")]
+        [EndpointSummary("PostRegister")]
+        [ProducesResponseType(statusCode: 400, type: typeof(ErrorResponse), Description ="Bad Request | Possible reasons:  - missing username  - invalid email  - password missing  - username already taken")]
         public virtual IActionResult PostRegister([FromBody]RegisterRequest payload, [FromQuery (Name = "latest")]int? latest)
         {
 

--- a/minitwit_csharp/minitwit/Api/Models/ErrorResponse.cs
+++ b/minitwit_csharp/minitwit/Api/Models/ErrorResponse.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -62,7 +63,9 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+/*          enum Newtonsoft.Json.Formatting
+            Specifies formatting options for the JsonTextWriter. */
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/FollowAction.cs
+++ b/minitwit_csharp/minitwit/Api/Models/FollowAction.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -62,7 +63,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/FollowsResponse.cs
+++ b/minitwit_csharp/minitwit/Api/Models/FollowsResponse.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -53,7 +54,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/LatestValue.cs
+++ b/minitwit_csharp/minitwit/Api/Models/LatestValue.cs
@@ -11,12 +11,14 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
+using System.Text.Json;
 
 namespace Org.OpenAPITools.Models
 { 
@@ -52,7 +54,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/Message.cs
+++ b/minitwit_csharp/minitwit/Api/Models/Message.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -71,7 +72,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/PostMessage.cs
+++ b/minitwit_csharp/minitwit/Api/Models/PostMessage.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -54,7 +55,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/Api/Models/RegisterRequest.cs
+++ b/minitwit_csharp/minitwit/Api/Models/RegisterRequest.cs
@@ -11,12 +11,13 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Org.OpenAPITools.Converters;
+/* using Newtonsoft.Json;
+using Org.OpenAPITools.Converters; */
 
 namespace Org.OpenAPITools.Models
 { 
@@ -71,7 +72,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>JSON string presentation of the object</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, new JsonSerializerOptions{WriteIndented = true});
         }
 
         /// <summary>

--- a/minitwit_csharp/minitwit/minitwit.cs
+++ b/minitwit_csharp/minitwit/minitwit.cs
@@ -21,6 +21,11 @@ builder.Services.AddSession(options =>
 
 builder.Services.AddOpenApi();
 
+/* builder.Services.AddControllers().AddJsonOptions(options =>
+{
+  options.JsonSerializerOptions.WriteIndented = true;
+}); */
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
Implement System.Text.Json and serialization from this library so code compiles.
Nothing from any of the generated code from openApi is implemented in our program it has just been moved into the folder.

There might have to be some refactoring done, I think it is possible to set the JsonSerializerOptions in minitwit.cs (currently commented out), so we dont have to reuse that line in every model.