### PR TITLE
 Add optional parameter to connectDB function

### DIFF
--- a/minitwit_csharp/minitwit/Api/Controllers/MinitwitApi.cs
+++ b/minitwit_csharp/minitwit/Api/Controllers/MinitwitApi.cs
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Controllers
 
             _mt.UpdateLatest(latest);
 
-            _mt.Connect_db();
+            _mt.Connect_db("/tmp/minitwit.db");
 
             var messages = _mt.Get_public_timeline();
 
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
 
             _mt.UpdateLatest(latest);
 
-            _mt.Connect_db();
+            _mt.Connect_db("/tmp/minitwit.db");
 
             if (_mt.Get_user_id(username) == null)
             {
@@ -291,7 +291,7 @@ namespace Org.OpenAPITools.Controllers
 
             _mt.UpdateLatest(latest);
 
-            _mt.Connect_db();
+            _mt.Connect_db("/tmp/minitwit.db");
 
             if (string.IsNullOrEmpty(payload.Content))
             {
@@ -326,7 +326,7 @@ namespace Org.OpenAPITools.Controllers
 
           _mt.UpdateLatest(latest);
 
-          _mt.Connect_db();
+          _mt.Connect_db("/tmp/minitwit.db");
 
           if (string.IsNullOrEmpty(payload.Username))
           {

--- a/minitwit_csharp/minitwit/minitwit.cs
+++ b/minitwit_csharp/minitwit/minitwit.cs
@@ -72,7 +72,7 @@ namespace minitwit
   {
     // Configuration
     // string DATABASE = "/tmp/minitwit.db";
-    string DATABASE = "./minitwit.db";
+    private const string Default_Database = "./minitwit.db";
     SqliteConnection? connection;
     private int PER_PAGE = 30;
     private static int _latest = -1;
@@ -82,9 +82,9 @@ namespace minitwit
     const int iterations = 50000;
     HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA256;
 
-    public SqliteConnection Connect_db()
+    public SqliteConnection Connect_db(string db_string = Default_Database)
     {
-      connection = new SqliteConnection($"Data Source= {DATABASE}");
+      connection = new SqliteConnection($"Data Source= {db_string}");
       connection.Open();
       return connection;
     }


### PR DESCRIPTION
This is done to allow us to specify if we want to connect to our seeded database or a database in another location, like the tmp folder. Allows us to run the the api tests without them changing the seeded database.

Will need refactoring, but will probably change when we use dbcontext?