### PR TITLE
Feature/add logging

### DIFF
--- a/.github/workflows/pr-main-test-env.yml
+++ b/.github/workflows/pr-main-test-env.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh/
@@ -49,6 +52,11 @@ jobs:
           chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
+      
+      - name: Copy configuration files to Droplet
+        run: |
+          scp -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./monitoring $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
 
       - name: Deploy to server
         run: >

--- a/.github/workflows/pr-main-test-env.yml
+++ b/.github/workflows/pr-main-test-env.yml
@@ -55,8 +55,11 @@ jobs:
       
       - name: Copy configuration files to Droplet
         run: |
-          scp -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
           scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./monitoring $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
+        env: 
+          SSH_USER_TEST_ENV: ${{ secrets.SSH_USER_TEST_ENV }}
+          SSH_HOST_TEST_ENV: ${{ secrets.SSH_HOST_TEST_ENV }}
 
       - name: Deploy to server
         run: >

--- a/.github/workflows/pr-main-test-env.yml
+++ b/.github/workflows/pr-main-test-env.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Copy configuration files to Droplet
         run: |
           scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
-          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./monitoring $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./monitoring $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/monitoring/
+          scp -r -i ~/.ssh/do_ssh_key ./logging $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/logging
         env: 
           SSH_USER_TEST_ENV: ${{ secrets.SSH_USER_TEST_ENV }}
           SSH_HOST_TEST_ENV: ${{ secrets.SSH_HOST_TEST_ENV }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -131,20 +131,6 @@ services:
       - discovery.type=single-node
     networks:
       - main
-    
-  kibana:
-    container_name: kibana
-    build:
-      dockerfile: ./Dockerfile
-      context: ./logging/kibana
-    ports:
-      - 5601:5601
-    depends_on:
-      - elasticsearch
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-    networks:
-      - main
 
 volumes:
   grafana-storage: {}

--- a/compose.yaml
+++ b/compose.yaml
@@ -124,11 +124,6 @@ services:
       - 9200:9200
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
-    environment:
-      - xpack.monitoring.enabled=true
-      - xpack.watcher.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - discovery.type=single-node
     networks:
       - main
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,7 @@ services:
       - ./data:/app/data
     environment:
       - DbPath=Server=mysql;Port=3306;Database=minitwit;Uid=root;Pwd=root;SslMode=None;AllowPublicKeyRetrieval=True;
+      - ELASTICSEARCH_URI=http://elasticsearch:9200
     
   mysql:
     build:
@@ -114,5 +115,37 @@ services:
       - ./monitoring/grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ./monitoring/grafana/dashboards:/etc/grafana/dashboards
 
+  elasticsearch:
+    container_name: elasticsearch
+    build:
+      dockerfile: ./Dockerfile
+      context: ./logging/elasticsearch
+    ports:
+      - 9200:9200
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    environment:
+      - xpack.monitoring.enabled=true
+      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+    networks:
+      - main
+    
+  kibana:
+    container_name: kibana
+    build:
+      dockerfile: ./Dockerfile
+      context: ./logging/kibana
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    networks:
+      - main
+
 volumes:
   grafana-storage: {}
+  elasticsearch-data: {}

--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.10

--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -1,1 +1,6 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.10
+
+ENV xpack.monitoring.enabled=true
+ENV xpack.watcher.enabled=false
+ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
+ENV discovery.type=single-node

--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -2,5 +2,5 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.10
 
 ENV xpack.monitoring.enabled=true
 ENV xpack.watcher.enabled=false
-ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
+ENV ES_JAVA_OPTS="-Xms256m -Xmx256m"
 ENV discovery.type=single-node

--- a/logging/kibana/Dockerfile
+++ b/logging/kibana/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.elastic.co/kibana/kibana:7.17.10

--- a/logging/kibana/Dockerfile
+++ b/logging/kibana/Dockerfile
@@ -1,1 +1,0 @@
-FROM docker.elastic.co/kibana/kibana:7.17.10

--- a/minitwit/appsettings.json
+++ b/minitwit/appsettings.json
@@ -1,9 +1,15 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Warning"
+      }
     }
+  },
+  "ElasticConfiguration": {
+    "Uri": "http://localhost:9200"
   },
   "AllowedHosts": "*"
 }

--- a/minitwit/appsettings.json
+++ b/minitwit/appsettings.json
@@ -8,8 +8,5 @@
       }
     }
   },
-  "ElasticConfiguration": {
-    "Uri": "http://localhost:9200"
-  },
   "AllowedHosts": "*"
 }

--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -5,14 +5,18 @@ using minitwit.Model;
 using Microsoft.EntityFrameworkCore;
 using Prometheus;
 using Serilog;
-using Elastic.Serilog.Sinks;
+//using Elastic.Serilog.Sinks;
 using Elastic.Ingest.Elasticsearch.DataStreams;
 using Elastic.Ingest.Elasticsearch;
+// using Microsoft.AspNetCore.Hosting;
+// using Microsoft.Extensions.Configuration;
+// using Microsoft.Extensions.Hosting;
+using Serilog.Sinks.Elasticsearch;
+// using System;
+using System.Reflection;
 
-Log.Logger = new LoggerConfiguration()
-  .MinimumLevel.Debug()
-  .Enrich.FromLogContext()
-  .CreateLogger();
+
+// MinitwitLogging.ConfigureLogging();
 
 try
 {
@@ -20,14 +24,21 @@ try
 
   var builder = WebApplication.CreateBuilder(args);
 
+  // builder.Configuration
+  //   .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+  //   .AddJsonFile(
+  //     $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json",
+  //     optional: true);
+  // builder.Services.AddSerilog();
+
   builder.Services.AddSerilog((services, loggerConfig) => loggerConfig
     .ReadFrom.Configuration(builder.Configuration)
     .Enrich.FromLogContext()
     .WriteTo.Console()
-    .WriteTo.Elasticsearch(new [] { new Uri("http://ip_of_droplet_running_elasticsearch:9200")}, opts =>
+    .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(Environment.GetEnvironmentVariable("ELASTICSEARCH_URI") ?? "http://localhost:9200"))
     {
-      opts.DataStream = new DataStreamName("logs", "miniTwit", "simulation");
-      opts.BootstrapMethod = BootstrapMethod.Failure;
+      AutoRegisterTemplate = true,
+		  IndexFormat = $"{Assembly.GetExecutingAssembly().GetName().Name.ToLower().Replace(".", "-")}-{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")?.ToLower().Replace(".", "-")}-{DateTime.UtcNow:yyyy-MM}"
     })
   );
 
@@ -106,7 +117,8 @@ try
 }
 catch (Exception ex)
 {
-  Log.Fatal(ex, "MiniTwit terminated unexpectedly");
+  Log.Fatal($"Failed to start {Assembly.GetExecutingAssembly().GetName().Name}", ex);
+	throw;
 }
 finally
 {
@@ -115,6 +127,41 @@ finally
 
 namespace minitwit
 {
+  // public static class MinitwitLogging
+  // {
+
+  //   public static void ConfigureLogging()
+  //   {
+  //     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+  //     var configuration = new ConfigurationBuilder()
+  //       .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+  //       .AddJsonFile(
+  //         $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json",
+  //         optional: true)
+  //       .Build();
+
+  //     Log.Logger = new LoggerConfiguration()
+  //       .Enrich.FromLogContext()
+  //       .Enrich.WithMachineName()
+  //       .WriteTo.Debug()
+  //       .WriteTo.Console()
+  //       .WriteTo.Elasticsearch(ConfigureElasticSink(configuration, environment))
+  //       .Enrich.WithProperty("Environment", environment)
+  //       .ReadFrom.Configuration(configuration)
+  //       .CreateLogger();
+  //   }
+
+  //   private static Serilog.Sinks.Elasticsearch.ElasticsearchSinkOptions ConfigureElasticSink(IConfigurationRoot configuration, string environment)
+  //   {
+  //     return new Serilog.Sinks.Elasticsearch.ElasticsearchSinkOptions(new Uri(configuration["ElasticConfiguration:Uri"]))
+  //     {
+  //       AutoRegisterTemplate = true,
+  //       IndexFormat = $"{Assembly.GetExecutingAssembly().GetName().Name.ToLower().Replace(".", "-")}-{environment?.ToLower().Replace(".", "-")}-{DateTime.UtcNow:yyyy-MM}"
+  //     };
+  //   }
+  // }
+  
+
   public static class MinitwitMetrics
   {
     public static readonly Counter TweetCounter = Metrics

--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -4,82 +4,114 @@ using minitwit;
 using minitwit.Model;
 using Microsoft.EntityFrameworkCore;
 using Prometheus;
+using Serilog;
+using Elastic.Serilog.Sinks;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Ingest.Elasticsearch;
 
+Log.Logger = new LoggerConfiguration()
+  .MinimumLevel.Debug()
+  .Enrich.FromLogContext()
+  .CreateLogger();
 
-var builder = WebApplication.CreateBuilder(args);
-
-// Add services to the container.
-builder.Services.AddRazorPages();
-
-builder.Services.AddDistributedMemoryCache();
-
-builder.Services.AddSession(options =>
+try
 {
-  options.IdleTimeout = TimeSpan.FromMinutes(15);
-  options.Cookie.HttpOnly = true;
-  options.Cookie.IsEssential = true;
-});
+  Log.Information("Starting MiniTwit application");
 
-builder.Services.AddOpenApi();
+  var builder = WebApplication.CreateBuilder(args);
 
-string? DbPath = Environment.GetEnvironmentVariable("DbPath");
+  builder.Services.AddSerilog((services, loggerConfig) => loggerConfig
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .WriteTo.Elasticsearch(new [] { new Uri("http://ip_of_droplet_running_elasticsearch:9200")}, opts =>
+    {
+      opts.DataStream = new DataStreamName("logs", "miniTwit", "simulation");
+      opts.BootstrapMethod = BootstrapMethod.Failure;
+    })
+  );
 
-if (string.IsNullOrEmpty(DbPath))
-{
-  builder.Services.AddDbContext<MinitwitContext>(options =>
-    options.UseSqlite("DataSource=../data/minitwit.db"));
-} else
-{
-  builder.Services.AddDbContext<MinitwitContext>(options =>
-    options.UseMySql(DbPath, ServerVersion.AutoDetect(DbPath)));
+  // Add services to the container.
+  builder.Services.AddRazorPages();
+
+  builder.Services.AddDistributedMemoryCache();
+
+  builder.Services.AddSession(options =>
+  {
+    options.IdleTimeout = TimeSpan.FromMinutes(15);
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+  });
+
+  builder.Services.AddOpenApi();
+
+  string? DbPath = Environment.GetEnvironmentVariable("DbPath");
+
+  if (string.IsNullOrEmpty(DbPath))
+  {
+    builder.Services.AddDbContext<MinitwitContext>(options =>
+      options.UseSqlite("DataSource=../data/minitwit.db"));
+  } else
+  {
+    builder.Services.AddDbContext<MinitwitContext>(options =>
+      options.UseMySql(DbPath, ServerVersion.AutoDetect(DbPath)));
+  }
+
+  builder.Services.AddScoped<MiniTwit>();
+
+  var app = builder.Build();
+
+  using (var scope = app.Services.CreateScope())
+  {
+      var services = scope.ServiceProvider;
+
+      var context = services.GetRequiredService<MinitwitContext>();
+      context.Database.EnsureCreated();
+
+      //Start the metrics at the amount of tweets and users in the database
+      var totalTweets = context.Messages.Count();
+      var totalUsers = context.Users.Count();
+      
+      MinitwitMetrics.TweetCounter.IncTo(totalTweets);
+      MinitwitMetrics.UserRegistrationCounter.IncTo(totalUsers);
+  }
+
+  // Configure the HTTP request pipeline.
+  if (!app.Environment.IsDevelopment())
+  {
+    app.UseExceptionHandler("/Error");
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+  }
+
+  // Add Prometheus metrics
+  app.UseHttpMetrics();
+  app.MapMetrics();
+
+  app.UseHttpsRedirection();
+
+  app.UseRouting();
+
+  app.UseAuthorization();
+
+  app.UseSession();
+
+  app.MapStaticAssets();
+  app.MapRazorPages()
+    .WithStaticAssets();
+
+  app.MapControllers();
+
+  app.Run();
 }
-
-builder.Services.AddScoped<MiniTwit>();
-
-var app = builder.Build();
-
-using (var scope = app.Services.CreateScope())
+catch (Exception ex)
 {
-    var services = scope.ServiceProvider;
-
-    var context = services.GetRequiredService<MinitwitContext>();
-    context.Database.EnsureCreated();
-
-    //Start the metrics at the amount of tweets and users in the database
-    var totalTweets = context.Messages.Count();
-    var totalUsers = context.Users.Count();
-    
-    MinitwitMetrics.TweetCounter.IncTo(totalTweets);
-    MinitwitMetrics.UserRegistrationCounter.IncTo(totalUsers);
+  Log.Fatal(ex, "MiniTwit terminated unexpectedly");
 }
-
-// Configure the HTTP request pipeline.
-if (!app.Environment.IsDevelopment())
+finally
 {
-  app.UseExceptionHandler("/Error");
-  // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-  app.UseHsts();
+  await Log.CloseAndFlushAsync();
 }
-
-// Add Prometheus metrics
-app.UseHttpMetrics();
-app.MapMetrics();
-
-app.UseHttpsRedirection();
-
-app.UseRouting();
-
-app.UseAuthorization();
-
-app.UseSession();
-
-app.MapStaticAssets();
-app.MapRazorPages()
-   .WithStaticAssets();
-
-app.MapControllers();
-
-app.Run();
 
 namespace minitwit
 {

--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -35,7 +35,7 @@ try
     .ReadFrom.Configuration(builder.Configuration)
     .Enrich.FromLogContext()
     .WriteTo.Console()
-    .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(Environment.GetEnvironmentVariable("ELASTICSEARCH_URI") ?? "http://localhost:9200"))
+    .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(Environment.GetEnvironmentVariable("ELASTICSEARCH_URI")))
     {
       AutoRegisterTemplate = true,
 		  IndexFormat = $"{Assembly.GetExecutingAssembly().GetName().Name.ToLower().Replace(".", "-")}-{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")?.ToLower().Replace(".", "-")}-{DateTime.UtcNow:yyyy-MM}"

--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -5,31 +5,14 @@ using minitwit.Model;
 using Microsoft.EntityFrameworkCore;
 using Prometheus;
 using Serilog;
-//using Elastic.Serilog.Sinks;
-using Elastic.Ingest.Elasticsearch.DataStreams;
-using Elastic.Ingest.Elasticsearch;
-// using Microsoft.AspNetCore.Hosting;
-// using Microsoft.Extensions.Configuration;
-// using Microsoft.Extensions.Hosting;
 using Serilog.Sinks.Elasticsearch;
-// using System;
 using System.Reflection;
-
-
-// MinitwitLogging.ConfigureLogging();
 
 try
 {
   Log.Information("Starting MiniTwit application");
 
   var builder = WebApplication.CreateBuilder(args);
-
-  // builder.Configuration
-  //   .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-  //   .AddJsonFile(
-  //     $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json",
-  //     optional: true);
-  // builder.Services.AddSerilog();
 
   builder.Services.AddSerilog((services, loggerConfig) => loggerConfig
     .ReadFrom.Configuration(builder.Configuration)
@@ -127,41 +110,6 @@ finally
 
 namespace minitwit
 {
-  // public static class MinitwitLogging
-  // {
-
-  //   public static void ConfigureLogging()
-  //   {
-  //     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-  //     var configuration = new ConfigurationBuilder()
-  //       .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-  //       .AddJsonFile(
-  //         $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json",
-  //         optional: true)
-  //       .Build();
-
-  //     Log.Logger = new LoggerConfiguration()
-  //       .Enrich.FromLogContext()
-  //       .Enrich.WithMachineName()
-  //       .WriteTo.Debug()
-  //       .WriteTo.Console()
-  //       .WriteTo.Elasticsearch(ConfigureElasticSink(configuration, environment))
-  //       .Enrich.WithProperty("Environment", environment)
-  //       .ReadFrom.Configuration(configuration)
-  //       .CreateLogger();
-  //   }
-
-  //   private static Serilog.Sinks.Elasticsearch.ElasticsearchSinkOptions ConfigureElasticSink(IConfigurationRoot configuration, string environment)
-  //   {
-  //     return new Serilog.Sinks.Elasticsearch.ElasticsearchSinkOptions(new Uri(configuration["ElasticConfiguration:Uri"]))
-  //     {
-  //       AutoRegisterTemplate = true,
-  //       IndexFormat = $"{Assembly.GetExecutingAssembly().GetName().Name.ToLower().Replace(".", "-")}-{environment?.ToLower().Replace(".", "-")}-{DateTime.UtcNow:yyyy-MM}"
-  //     };
-  //   }
-  // }
-  
-
   public static class MinitwitMetrics
   {
     public static readonly Counter TweetCounter = Metrics

--- a/minitwit/minitwit.csproj
+++ b/minitwit/minitwit.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Elastic.Serilog.Sinks" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.*-*" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
@@ -16,6 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/minitwit/minitwit.csproj
+++ b/minitwit/minitwit.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -1,6 +1,7 @@
 FROM grafana/grafana:12.1
 
 ENV PROMETHEUS_HOST='host.docker.internal:9090'
+ENV ELASTICSEARCH_HOST='host.docker.internal:9200'
 
 COPY dashboards /etc/grafana/dashboards
 COPY datasources /etc/grafana/datasources

--- a/monitoring/grafana/dashboards/logs.json
+++ b/monitoring/grafana/dashboards/logs.json
@@ -1,0 +1,119 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "bfhasaukfudq8b"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.1.10",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "bfhasaukfudq8b"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "settings": {
+                "limit": "100"
+              },
+              "type": "logs"
+            }
+          ],
+          "query": "",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "title": "Logs",
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Logs",
+  "uid": "b2bc44df-02cc-4914-afa4-d6afb2413bbc",
+  "version": 4
+}

--- a/monitoring/grafana/dashboards/logs.json
+++ b/monitoring/grafana/dashboards/logs.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "elasticsearch",
-        "uid": "bfhasaukfudq8b"
+        "uid": "PAE1B8C8635429669"
       },
       "fieldConfig": {
         "defaults": {

--- a/monitoring/grafana/datasources/datasources.yml
+++ b/monitoring/grafana/datasources/datasources.yml
@@ -7,3 +7,12 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+  - name: elasticsearch
+    type: elasticsearch
+    url: http://elasticsearch:9200
+    access: proxy
+    jsonData:
+      esVersion: 7
+      timeField: "@timestamp"
+    isDefault: false
+    editable: false

--- a/remote_files/prod_env/compose.yaml
+++ b/remote_files/prod_env/compose.yaml
@@ -31,11 +31,28 @@ services:
     networks:
       - main
     volumes:
+      - grafana-storage:/var/lib/grafana
       # Save the dasboards to the container, so it can build them.
       - ../monitoring/grafana/datasources/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml
       - ../monitoring/grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ../monitoring/grafana/dashboards:/etc/grafana/dashboards
 
+    elasticsearch:
+      container_name: elasticsearch
+      build:
+        dockerfile: ./Dockerfile
+        context: ../logging/elasticsearch
+      ports:
+        - 9200:9200
+      volumes:
+        - elasticsearch-data:/usr/share/elasticsearch/data
+      networks:
+        - main
+
 networks:
   main:
     driver: bridge
+
+volumes:
+  elasticsearch-data: {}
+  grafana-storage: {}

--- a/remote_files/prod_env/compose.yaml
+++ b/remote_files/prod_env/compose.yaml
@@ -38,17 +38,17 @@ services:
       - ../monitoring/grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ../monitoring/grafana/dashboards:/etc/grafana/dashboards
 
-    elasticsearch:
-      container_name: elasticsearch
-      build:
-        dockerfile: ./Dockerfile
-        context: ../logging/elasticsearch
-      ports:
-        - 9200:9200
-      volumes:
-        - elasticsearch-data:/usr/share/elasticsearch/data
-      networks:
-        - main
+  elasticsearch:
+    container_name: elasticsearch
+    build:
+      dockerfile: ./Dockerfile
+      context: ../logging/elasticsearch
+    ports:
+      - 9200:9200
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    networks:
+      - main
 
 networks:
   main:

--- a/remote_files/prod_env/compose.yaml
+++ b/remote_files/prod_env/compose.yaml
@@ -8,6 +8,7 @@ services:
       - ../data:/app/data
     environment:
       - DbPath=${db_connection}
+      - ELASTICSEARCH_URI=http://elasticsearch:9200
     networks:
       - main
 

--- a/remote_files/test_env/compose.yaml
+++ b/remote_files/test_env/compose.yaml
@@ -31,11 +31,28 @@ services:
     networks:
       - main
     volumes:
+      - grafana-storage:/var/lib/grafana
       # Save the dasboards to the container, so it can build them.
       - ../monitoring/grafana/datasources/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml
       - ../monitoring/grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ../monitoring/grafana/dashboards:/etc/grafana/dashboards
 
+  elasticsearch:
+    container_name: elasticsearch
+    build:
+      dockerfile: ./Dockerfile
+      context: ../logging/elasticsearch
+    ports:
+      - 9200:9200
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    networks:
+      - main
+
 networks:
   main:
     driver: bridge
+
+volumes:
+  elasticsearch-data: {}
+  grafana-storage: {}

--- a/remote_files/test_env/compose.yaml
+++ b/remote_files/test_env/compose.yaml
@@ -8,6 +8,7 @@ services:
       - ../data:/app/data
     environment:
       - DbPath=${db_connection}
+      - ELASTICSEARCH_URI=http://elasticsearch:9200
     networks:
       - main
 


### PR DESCRIPTION
This pull request introduces centralized logging with Elasticsearch and Serilog, and integrates log monitoring into Grafana. The main changes include the addition of an Elasticsearch service, configuration of Serilog to send logs to Elasticsearch, and updates to Grafana to visualize logs. These updates enhance observability and troubleshooting capabilities for the application.

**Logging Infrastructure**

* Added an `elasticsearch` service to all Docker Compose environments (`compose.yaml`, `remote_files/prod_env/compose.yaml`, `remote_files/test_env/compose.yaml`), including persistent storage and network configuration. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR118-R132) [[2]](diffhunk://#diff-4b3e70b47068c4ec05ebccd3a2755e2006c6bf6cf29c92497d7a91232cffa7d1R35-R59) [[3]](diffhunk://#diff-3cf91ff16851ceeade42f74219a280cee3c7777e210d61e9bb4e85fa5d6fe041R35-R59)
* Created a new Dockerfile for Elasticsearch in `logging/elasticsearch/Dockerfile`, configuring it for single-node operation and enabling monitoring.
* Set the `ELASTICSEARCH_URI` environment variable in application service definitions to inform the app of the Elasticsearch endpoint. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR28) [[2]](diffhunk://#diff-4b3e70b47068c4ec05ebccd3a2755e2006c6bf6cf29c92497d7a91232cffa7d1R11) [[3]](diffhunk://#diff-3cf91ff16851ceeade42f74219a280cee3c7777e210d61e9bb4e85fa5d6fe041R11)

**Application Logging**

* Switched from default logging to Serilog in `minitwit/appsettings.json` and added Serilog and Elasticsearch sink packages in `minitwit.csproj`. [[1]](diffhunk://#diff-cfdb90cbd2ad88fe1c26fc3ebfc2f21f64856dfc600e6c33c4be321b499fd98bL2-R8) [[2]](diffhunk://#diff-8cff99ea9dbcbde793f98ed46d53f1ce8c5a2c090ffbb1ed70edd1157333da36R10) [[3]](diffhunk://#diff-8cff99ea9dbcbde793f98ed46d53f1ce8c5a2c090ffbb1ed70edd1157333da36R20-R23)
* Updated `minitwit/minitwit.cs` to configure Serilog, enrich logs, and send them to both console and Elasticsearch. Also wrapped application startup in try/catch/finally for robust logging and graceful shutdown. [[1]](diffhunk://#diff-0e1327e2aea11107deaf5c48dffb4026ef3420d3239b5f5bcfca775245a47722R7-R27) [[2]](diffhunk://#diff-0e1327e2aea11107deaf5c48dffb4026ef3420d3239b5f5bcfca775245a47722R100-R109)

**Monitoring and Visualization**

* Updated Grafana Dockerfile and configuration to add Elasticsearch as a data source (`monitoring/grafana/Dockerfile`, `monitoring/grafana/datasources/datasources.yml`). [[1]](diffhunk://#diff-e50588aff18b7075fac01d055b130ef6e84708119180ed192f58f93dbd3bd2c8R4) [[2]](diffhunk://#diff-d0bb6c284a4d7aeabc2116ea29dcba4dfd53848f06adfd5b5a9ec7e483fe5ddcR10-R18)
* Added a new Grafana dashboard (`monitoring/grafana/dashboards/logs.json`) to visualize logs from Elasticsearch.

_Summary generated by ChatGPT_