### PR TITLE
Bug/stateless metrics

### DIFF
--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -56,13 +56,6 @@ try
 
     var context = services.GetRequiredService<MinitwitContext>();
     await context.Database.EnsureCreatedAsync();
-
-    //Start the metrics at the amount of tweets and users in the database
-    var totalTweets = await context.Messages.CountAsync();
-    var totalUsers = await context.Users.CountAsync();
-
-    MinitwitMetrics.TweetCounter.IncTo(totalTweets);
-    MinitwitMetrics.UserRegistrationCounter.IncTo(totalUsers);
   }
 
   // Configure the HTTP request pipeline.
@@ -75,6 +68,26 @@ try
 
   // Add Prometheus metrics
   app.UseHttpMetrics();
+
+  // Before collecting metrics, we want to update the total amount of tweets and users, so we get the latest values when scraping
+  DateTime _lastUpdate = DateTime.MinValue;
+  Metrics.DefaultRegistry.AddBeforeCollectCallback(async (cancel) =>
+  {
+      if ((DateTime.Now - _lastUpdate).TotalSeconds < 30) return; // Skip if too recent
+      using (var scope = app.Services.CreateScope()) //The DbContext is a scoped service, so we need to create a scope to get it
+      {
+          var context = scope.ServiceProvider.GetRequiredService<MinitwitContext>();
+          
+          // Query the database for the absolute latest numbers
+          var totalTweets = await context.Messages.CountAsync(cancel);
+          var totalUsers = await context.Users.CountAsync(cancel);
+
+          // Update the Gauges
+          MinitwitMetrics.TotalTweets.Set(totalTweets);
+          MinitwitMetrics.TotalUsers.Set(totalUsers);
+          _lastUpdate = DateTime.Now;
+      }
+  });
 
   app.UseHttpsRedirection();
 
@@ -108,11 +121,11 @@ namespace minitwit
 {
   public static class MinitwitMetrics
   {
-    public static readonly Counter TweetCounter = Metrics
-            .CreateCounter("minitwit_tweets_total", "Total number of tweets posted.");
+    public static readonly Gauge TotalTweets = Metrics
+            .CreateGauge("minitwit_tweets_total", "Total number of tweets in db");
 
-    public static readonly Counter UserRegistrationCounter = Metrics
-            .CreateCounter("minitwit_registrations_total", "Total number of user registrations.");
+    public static readonly Gauge TotalUsers = Metrics
+            .CreateGauge("minitwit_users_total", "Total number of users in db");
   }
   public class MiniTwit(MinitwitContext minitwitContext)
   {
@@ -250,9 +263,6 @@ namespace minitwit
       });
       await minitwitContext.SaveChangesAsync();
       Log.Information("Registered user with name: {username} and email: {email}", username, email);
-
-      //Increment the amount of users for the metrics:
-      MinitwitMetrics.UserRegistrationCounter.Inc();
     }
 
 
@@ -318,9 +328,6 @@ namespace minitwit
         await minitwitContext.SaveChangesAsync();
 
         Log.Information("User {username} posted a tweet, with length: {TextLength}", username, text.Length);
-
-        //Increment the amount of users for the metrics:
-        MinitwitMetrics.TweetCounter.Inc();
       }
     }
 

--- a/monitoring/grafana/dashboards/business.json
+++ b/monitoring/grafana/dashboards/business.json
@@ -175,7 +175,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(minitwit_tweets_total[24h])",
+          "expr": "minitwit_tweets_total - minitwit_tweets_total offset 24h",
           "format": "table",
           "instant": false,
           "legendFormat": "__auto",
@@ -241,7 +241,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "minitwit_registrations_total",
+          "expr": "minitwit_users_total",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -335,14 +335,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "increase(minitwit_registrations_total[1h])",
+          "expr": "minitwit_users_total - minitwit_users_total offset 1h",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Amount of users registrered",
+      "title": "Amount of users registrered in the last hour",
       "description": "Registration rate per hour. Used to track the success of marketing efforts or onboarding health.",
       "type": "timeseries"
     },
@@ -440,7 +440,7 @@
         }
       ],
       "title": "Duration of HTTP Requests (Latency)",
-      "description": "Average response time from a user's perspective. High latency directly correlates to poor user satisfaction.",
+      "description": "Average response time over the last 5 minutes from a user's perspective. High latency directly correlates to poor user satisfaction.",
       "type": "timeseries"
     }
   ],

--- a/monitoring/grafana/dashboards/connection.json
+++ b/monitoring/grafana/dashboards/connection.json
@@ -360,9 +360,7 @@
       "id": 1,
       "options": {
         "legend": {
-          "calcs": [
-            "sum"
-          ],
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true


### PR DESCRIPTION
Retrieve the total amount of users and tweets from db instead of a counter in each replica.
Update the grafana dashboards accordingly.

Be aware that the dashboards still have some issues regarding different replicas that we have not handled here.