### PR TITLE
Set up reverse proxy for Minitwit production enviroment to bigtwit.app

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -24,7 +24,7 @@ scrape_configs:
     scrape_interval: 5s
     scheme: https
     static_configs:
-      - targets: ['monitor-test.bigtwit.app']
+      - targets: ['monitor.bigtwit.app']
         labels:
           group: 'production'
 

--- a/remote_files/prod_env/compose_stack.yaml
+++ b/remote_files/prod_env/compose_stack.yaml
@@ -1,14 +1,80 @@
 services:
+  # The Traefik Service
+  traefik:
+    image: traefik:v3.6 # One of the newest versions of Traefik
+    command:
+      - "--api.insecure=true" # A flag to tell this is unsecure, but should be removed inour prod enviroment
+      - "--providers.docker=true"
+      - "--providers.swarm=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80" ## for unencrypted HTTP traffic
+      - "--entrypoints.websecure.address=:443" ## For encrypted HTTPS traffic
+      - "--entrypoints.alt.address=:5035"   ## OBS!! WE TRY FIX TO MAKE OLD IP WORK
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=csfr@itu.dk"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "5035:5035"  # OBS!! WE TRY FIX TO MAKE OLD IP WORK
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "letsencrypt:/letsencrypt"
+    networks:
+      - web-public
+    deploy:
+      labels:
+        - "traefik.enable=false" # to silence the "port missing" errors
+
+
   minitwit:
     image: ${DOCKER_USERNAME}/minitwitimage
-    ports:
-      - 5035:8080
-      - 9091:9091
+    #PORTS are removed, and moved to Traefik
     environment:
       - DbPath=${db_connection}
       - Serilog__WriteTo__0__Args__nodes__0=http://${MONITOR_AND_LOGGING_PRIVATE_IP:-elasticsearch}:9200
+    networks:
+      - web-public
     deploy:
-      replicas: 3
+      replicas: 6
       update_config:
         delay: 10s
         order: start-first
+    labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.minitwit.rule=Host(`bigtwit.app`) || Host(`www.bigtwit.app`)"
+        - "traefik.http.routers.minitwit.entrypoints=websecure"
+        - "traefik.http.routers.minitwit.tls.certresolver=myresolver"
+        - "traefik.http.services.minitwit-app-svc.loadbalancer.server.port=8080" # define the service
+        - "traefik.http.routers.minitwit.service=minitwit-app-svc" # the internal port of Minitwit
+
+        ## Ensure that www.bigtwit.app redirects to bigtwit.app
+        - "traefik.http.routers.minitwit.middlewares=www-redirect"
+        - "traefik.http.middlewares.www-redirect.redirectregex.regex=^https?://www.bigtwit.app/(.*)"
+        - "traefik.http.middlewares.www-redirect.redirectregex.replacement=https://bigtwit.app/$${1}"
+        - "traefik.http.middlewares.www-redirect.redirectregex.permanent=true"
+
+        # Add access via IP also:
+        - "traefik.http.routers.minitwit-ip.rule=Host(`209.38.114.224`)"
+        - "traefik.http.routers.minitwit-ip.entrypoints=alt"
+        - "traefik.http.routers.minitwit-ip.service=minitwit-app-svc"
+
+        # Monitoring
+        - "traefik.http.routers.minitwit-metrics.rule=Host(`monitor.bigtwit.app`)"
+        - "traefik.http.routers.minitwit-metrics.entrypoints=websecure"
+        - "traefik.http.routers.minitwit-metrics.tls.certresolver=myresolver"
+        - "traefik.http.services.minitwit-metrics-svc.loadbalancer.server.port=9091"  # define the service for monitoring
+        - "traefik.http.routers.minitwit-metrics.service=minitwit-metrics-svc" # Define the local port this url looks at
+
+        # ADD STICKY SESSIONS FIX
+        - "traefik.http.services.minitwit-app-svc.loadbalancer.sticky.cookie=true"   # Add the cookie on the containers
+        - "traefik.http.services.minitwit-app-svc.loadbalancer.sticky.cookie.httponly=true" # Secure the cookie so we only can acess it via http and not JAVASCRIPT for example
+        - "traefik.http.services.minitwit-app-svc.loadbalancer.sticky.cookie.secure=true" # Secure the cookie only by sending it over http
+        - "traefik.http.services.minitwit-app-svc.loadbalancer.sticky.cookie.name=minitwit_sticky" # Rename the cookie so it is not conflicting with other 
+
+networks:
+  web-public:
+    driver: overlay # For communication across droplets.
+
+volumes:
+  letsencrypt:


### PR DESCRIPTION
Add compose for prod introducing Traefik as a reverse proxy and load balancer, enhancing routing, SSL/TLS management, and sticky session support. 

Includes making our application available on bigtwit.app and www.bigtwit.app
And monitoring of it available at monitor.bigtwit.app

It also keeps the IP open for now, but this should be removed when the URL is updated in Helges documents (so the simulator keeps working)