### PR TITLE
Update how ports are mapped in traefik

### DIFF
--- a/remote_files/prod_env/compose_stack.yaml
+++ b/remote_files/prod_env/compose_stack.yaml
@@ -13,8 +13,14 @@ services:
       - "--certificatesresolvers.myresolver.acme.email=csfr@itu.dk"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
-      - "80:80"
-      - "443:443"
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "letsencrypt:/letsencrypt"
@@ -62,7 +68,7 @@ services:
         - "traefik.http.services.minitwit-metrics-svc.loadbalancer.server.port=9091"  # define the service for monitoring
         - "traefik.http.routers.minitwit-metrics.service=minitwit-metrics-svc" # Define the local port this url looks at
         # Restrict access to the monitoring endpoint to only the monitor IP
-        - "traefik.http.middlewares.monitor-ip-whitelist.ipallowlist.sourcerange=${MONITOR_AND_LOGGING_PRIVATE_IP}"
+        - "traefik.http.middlewares.monitor-ip-whitelist.ipallowlist.sourcerange=${MONITOR_AND_LOGGING_PUBLIC_IP}"
         - "traefik.http.routers.minitwit-metrics.middlewares=monitor-ip-whitelist"
 
         # ADD STICKY SESSIONS FIX

--- a/remote_files/test_env/compose_stack.yaml
+++ b/remote_files/test_env/compose_stack.yaml
@@ -13,8 +13,14 @@ services:
       - "--certificatesresolvers.myresolver.acme.email=csfr@itu.dk"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
-      - "80:80"
-      - "443:443"
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "letsencrypt:/letsencrypt"
@@ -61,7 +67,7 @@ services:
         - "traefik.http.services.minitwit-metrics-svc.loadbalancer.server.port=9091"  # define the service for monitoring
         - "traefik.http.routers.minitwit-metrics.service=minitwit-metrics-svc" # Define the local port this url looks at
         # Restrict access to the monitoring endpoint to only the monitor IP
-        - "traefik.http.middlewares.monitor-ip-whitelist.ipallowlist.sourcerange=${TEST_MONITOR_AND_LOGGING_PRIVATE_IP}"
+        - "traefik.http.middlewares.monitor-ip-whitelist.ipallowlist.sourcerange=${TEST_MONITOR_AND_LOGGING_PUBLIC_IP}"
         - "traefik.http.routers.minitwit-metrics.middlewares=monitor-ip-whitelist"
 
         # ADD STICKY SESSIONS FIX


### PR DESCRIPTION
The former port mapping meant that when request hit traffic and was handled internally, apparently the internal docker network took over, which meant when we made it to looking at the ip of the request for monitoring to check if it was the whitelisted ip, the ip for the request had ended up being the managers own private ip, instead of the original ip of the request (the monitor ip). Also changed whitelisting to the public ip of the monitoring droplet, as that is the one that is attached to the request