### PR TITLE
Security hardening for Docker images

### DIFF
--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -4,3 +4,6 @@ ENV xpack.monitoring.enabled=true
 ENV xpack.watcher.enabled=false
 ENV ES_JAVA_OPTS="-Xms256m -Xmx256m"
 ENV discovery.type=single-node
+
+# Run as non-root user for security (Elasticsearch image has a built-in user with UID 1000)
+USER 1000 

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -3,7 +3,9 @@ FROM grafana/grafana:12.1
 ENV PROMETHEUS_HOST='host.docker.internal:9090'
 ENV ELASTICSEARCH_HOST='host.docker.internal:9200'
 
-COPY dashboards /etc/grafana/dashboards
-COPY datasources /etc/grafana/datasources
+COPY --chown=472:472 dashboards /etc/grafana/dashboards
+COPY --chown=472:472 datasources /etc/grafana/datasources
 
 EXPOSE 3000
+
+USER 472

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,5 +1,7 @@
 FROM prom/prometheus:v3.5.1
 
-COPY prometheus.yml /etc/prometheus/prometheus.yml
+COPY --chown=65534:65534 prometheus.yml /etc/prometheus/prometheus.yml
 
 EXPOSE 9090
+
+USER 65534

--- a/remote_files/prod_env/compose_stack.yaml
+++ b/remote_files/prod_env/compose_stack.yaml
@@ -3,7 +3,6 @@ services:
   traefik:
     image: traefik:v3.6 # One of the newest versions of Traefik
     command:
-      - "--api.insecure=true" # A flag to tell this is unsecure, but should be removed inour prod enviroment
       - "--providers.docker=true"
       - "--providers.swarm=true"
       - "--providers.docker.exposedbydefault=false"


### PR DESCRIPTION
This pull request improves the security posture of the Docker images used for Elasticsearch, Grafana, and Prometheus by ensuring they run as non-root users, and makes a minor configuration adjustment to the Traefik service in the production Docker Compose stack.

**Security hardening for Docker images:**

* Updated `logging/elasticsearch/Dockerfile` to run Elasticsearch as the built-in non-root user (UID 1000) for improved container security.
* Modified `monitoring/grafana/Dockerfile` to copy configuration files with the correct ownership (`--chown=472:472`) and run Grafana as the non-root user (UID 472).
* Changed `monitoring/prometheus/Dockerfile` to copy the configuration file with the correct ownership (`--chown=65534:65534`) and run Prometheus as the non-root user (UID 65534).

**Production configuration updates:**

* Removed the insecure API flag (`--api.insecure=true`) from the Traefik service configuration in `remote_files/prod_env/compose_stack.yaml`

*Summary generated by @copilot; verified by @Carmish .*