### PR TITLE
Security hardening

### DIFF
--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -4,3 +4,6 @@ ENV xpack.monitoring.enabled=true
 ENV xpack.watcher.enabled=false
 ENV ES_JAVA_OPTS="-Xms256m -Xmx256m"
 ENV discovery.type=single-node
+
+# Run as non-root user for security (Elasticsearch image has a built-in user with UID 1000)
+USER 1000 

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -3,8 +3,8 @@ FROM grafana/grafana:12.1
 ENV PROMETHEUS_HOST='host.docker.internal:9090'
 ENV ELASTICSEARCH_HOST='host.docker.internal:9200'
 
-COPY --chown=472:472 dashboards /etc/grafana/dashboards
-COPY --chown=472:472 datasources /etc/grafana/datasources
+COPY --chown=root:root --chmod=755 dashboards /etc/grafana/dashboards
+COPY --chown=root:root --chmod=755 datasources /etc/grafana/datasources
 
 EXPOSE 3000
 

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -3,7 +3,9 @@ FROM grafana/grafana:12.1
 ENV PROMETHEUS_HOST='host.docker.internal:9090'
 ENV ELASTICSEARCH_HOST='host.docker.internal:9200'
 
-COPY dashboards /etc/grafana/dashboards
-COPY datasources /etc/grafana/datasources
+COPY --chown=472:472 dashboards /etc/grafana/dashboards
+COPY --chown=472:472 datasources /etc/grafana/datasources
 
 EXPOSE 3000
+
+USER 472

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,6 +1,6 @@
 FROM prom/prometheus:v3.5.1
 
-COPY --chown=65534:65534 prometheus.yml /etc/prometheus/prometheus.yml
+COPY --chown=root:root --chmod=755 prometheus.yml /etc/prometheus/prometheus.yml
 
 EXPOSE 9090
 

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,5 +1,7 @@
 FROM prom/prometheus:v3.5.1
 
-COPY prometheus.yml /etc/prometheus/prometheus.yml
+COPY --chown=65534:65534 prometheus.yml /etc/prometheus/prometheus.yml
 
 EXPOSE 9090
+
+USER 65534

--- a/remote_files/prod_env/compose_stack.yaml
+++ b/remote_files/prod_env/compose_stack.yaml
@@ -3,7 +3,6 @@ services:
   traefik:
     image: traefik:v3.6 # One of the newest versions of Traefik
     command:
-      - "--api.insecure=true" # A flag to tell this is unsecure, but should be removed inour prod enviroment
       - "--providers.docker=true"
       - "--providers.swarm=true"
       - "--providers.docker.exposedbydefault=false"


### PR DESCRIPTION
This pull request improves the security posture of the Docker images used for Elasticsearch, Grafana, and Prometheus by ensuring they run as non-root users, and makes a minor configuration adjustment to the Traefik service in the production Docker Compose stack.

**Security hardening for Docker images:**

* [`logging/elasticsearch/Dockerfile`](diffhunk://#diff-67f9fb66ba71c39647605ac613ddccccb4b147dc97a04b10da4cb3f36ed310e6R7-R9): Configured the container to run as the non-root user with UID 1000, leveraging the built-in Elasticsearch user for improved security.
* [`monitoring/grafana/Dockerfile`](diffhunk://#diff-e50588aff18b7075fac01d055b130ef6e84708119180ed192f58f93dbd3bd2c8L6-R11): Updated the `COPY` instructions to set ownership to `root:root` and permissions to `755` for `dashboards` and `datasources` directories, and set the container to run as non-root user `472`.
* [`monitoring/prometheus/Dockerfile`](diffhunk://#diff-b7713e0ca52c4f4e8346b6ea247ceb5c367e2bf7574bf929bed8aee9622d1cd1L3-R7): Updated the `COPY` instruction for `prometheus.yml` to set ownership to `root:root` and permissions to `755`, and configured the container to run as non-root user `65534`.

**Production configuration updates:**

* Removed the insecure API flag (`--api.insecure=true`) from the Traefik service configuration in `remote_files/prod_env/compose_stack.yaml`

*Summary generated by @copilot; verified by @Carmish .*