### PR TITLE
Add 404 page

### DIFF
--- a/minitwit/Pages/Follow.cshtml.cs
+++ b/minitwit/Pages/Follow.cshtml.cs
@@ -10,15 +10,21 @@ public class FollowModel(MiniTwit minitwit) : PageModel
   private readonly MiniTwit minitwit = minitwit;
   public async Task<IActionResult> OnGet(string username)
   {
-    //Get current user and ensure it is not null
-    string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
-    if(logged_in_username != null)
-    {
-      await minitwit.Follow_user(logged_in_username, username);
-      TempData["Flash"] = $"You are now following \"{username}\"";
-      Console.WriteLine(logged_in_username + " now following " + username);
-    }
+    try {
+      //Get current user and ensure it is not null
+      string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
+      if(logged_in_username != null)
+      {
+        await minitwit.Follow_user(logged_in_username, username);
+        TempData["Flash"] = $"You are now following \"{username}\"";
+        Console.WriteLine(logged_in_username + " now following " + username);
+      }
 
-    return RedirectToPage("UserTimeline", new { username });
+      return RedirectToPage("UserTimeline", new { username });
+    }
+    catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
+    {
+        return NotFound("404: User not found");
+    }
   }
 }

--- a/minitwit/Pages/Unfollow.cshtml.cs
+++ b/minitwit/Pages/Unfollow.cshtml.cs
@@ -22,7 +22,7 @@ public class UnfollowModel(MiniTwit minitwit) : PageModel
       }
 
       return RedirectToPage("UserTimeline", new { username });
-    } 
+    }
     catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
     {
         return NotFound("404: User not found");

--- a/minitwit/Pages/Unfollow.cshtml.cs
+++ b/minitwit/Pages/Unfollow.cshtml.cs
@@ -10,15 +10,22 @@ public class UnfollowModel(MiniTwit minitwit) : PageModel
   private readonly MiniTwit minitwit = minitwit;
   public async Task<IActionResult> OnGet(string username)
   {
-    //Get current user and ensure it is not null
-    string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
-    if(logged_in_username != null)
+    try
     {
-      await minitwit.Unfollow_user(logged_in_username, username);
-      TempData["Flash"] = $"You are no longer following \"{username}\"";
-      Console.WriteLine(logged_in_username + " no longer following " + username);
-    }
+      //Get current user and ensure it is not null
+      string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
+      if(logged_in_username != null)
+      {
+        await minitwit.Unfollow_user(logged_in_username, username);
+        TempData["Flash"] = $"You are no longer following \"{username}\"";
+        Console.WriteLine(logged_in_username + " no longer following " + username);
+      }
 
-    return RedirectToPage("UserTimeline", new { username });
+      return RedirectToPage("UserTimeline", new { username });
+    } 
+    catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
+    {
+        return NotFound("404: User not found");
+    }
   }
 }

--- a/minitwit/Pages/UserTimeline.cshtml.cs
+++ b/minitwit/Pages/UserTimeline.cshtml.cs
@@ -12,7 +12,7 @@ public class UserTimelineModel(MiniTwit minitwit) : PageModel
   public bool Followed { get; set; }
   public async Task<IActionResult> OnGet(string username)
   {
-    try 
+    try
     {
       string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
 
@@ -22,7 +22,7 @@ public class UserTimelineModel(MiniTwit minitwit) : PageModel
         Followed = await minitwit.Is_following(logged_in_username, username);
       }
       return Page();
-    } 
+    }
     catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
     {
         return NotFound("404: User not found");

--- a/minitwit/Pages/UserTimeline.cshtml.cs
+++ b/minitwit/Pages/UserTimeline.cshtml.cs
@@ -12,13 +12,21 @@ public class UserTimelineModel(MiniTwit minitwit) : PageModel
   public bool Followed { get; set; }
   public async Task<IActionResult> OnGet(string username)
   {
-    string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
-
-    Messages = await minitwit.Get_user_timeline(username);
-    if(logged_in_username != null)
+    try 
     {
-      Followed = await minitwit.Is_following(logged_in_username, username);
+      string? logged_in_username = HttpContext.Session.GetString("Logged_In_Username");
+
+      Messages = await minitwit.Get_user_timeline(username);
+      if(logged_in_username != null)
+      {
+        Followed = await minitwit.Is_following(logged_in_username, username);
+      }
+      return Page();
+    } 
+    catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
+    {
+        // This returns a 404 status code instead of a 500
+        return NotFound("404: User not found");
     }
-    return Page();
   }
 }

--- a/minitwit/Pages/UserTimeline.cshtml.cs
+++ b/minitwit/Pages/UserTimeline.cshtml.cs
@@ -25,7 +25,6 @@ public class UserTimelineModel(MiniTwit minitwit) : PageModel
     } 
     catch (Exception ex) when (ex.Message.Contains("User doesn't exist"))
     {
-        // This returns a 404 status code instead of a 500
         return NotFound("404: User not found");
     }
   }

--- a/minitwit/minitwit.cs
+++ b/minitwit/minitwit.cs
@@ -61,6 +61,7 @@ try
   // Configure the HTTP request pipeline.
   if (!app.Environment.IsDevelopment())
   {
+    app.UseStatusCodePages();
     app.UseExceptionHandler("/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
@@ -104,6 +105,11 @@ try
   app.MapControllers();
 
   app.MapHealthChecks("/healthz");
+
+  app.MapFallback(context => {
+    context.Response.StatusCode = 404;
+    return Task.CompletedTask;
+  });
 
   await app.RunAsync();
 }


### PR DESCRIPTION
Return 404 (Not Found) on requests with invalid endpoints.

This will make our HTTP success rate in the monitor dashboard drop less as invalid endpoints will no longer be tracked as errors.


* Added `try-catch` blocks to the `OnGet` methods of `FollowModel`, `UnfollowModel`, and `UserTimelineModel` to catch cases where the user does not exist and return a 404 Not Found response. [[1]](diffhunk://#diff-bb61ef035dfc960dbf87a7c9ae4503f100d4976d717f78548a0c68e2e60ef77cR13) [[2]](diffhunk://#diff-bb61ef035dfc960dbf87a7c9ae4503f100d4976d717f78548a0c68e2e60ef77cR25-R29) [[3]](diffhunk://#diff-23e754821f176694f844ce63a43ecb0fb56437efbe731f60a3b69153ce94973dR12-R13) [[4]](diffhunk://#diff-23e754821f176694f844ce63a43ecb0fb56437efbe731f60a3b69153ce94973dR26-R30) [[5]](diffhunk://#diff-3728c53abdf82d5a05e678b81d1ff367427d725bc6b1d3d3a3828a4c679d6510R14-R15) [[6]](diffhunk://#diff-3728c53abdf82d5a05e678b81d1ff367427d725bc6b1d3d3a3828a4c679d6510R26-R30)

* Added a fallback route to return a 404 status code for any unmatched routes, ensuring users receive a consistent 404 response when accessing non-existent pages.