### PR TITLE
Add and rename steps in workflows

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -71,6 +71,13 @@ jobs:
           chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
+      
+      - name: Copy config files to Droplet
+        run: |
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER@$SSH_HOST:/minitwit/
+        env: 
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
 
       - name: Deploy to server
         # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile

--- a/.github/workflows/pr-main-test-env.yml
+++ b/.github/workflows/pr-main-test-env.yml
@@ -65,14 +65,14 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
       
-      - name: Copy configuration files to Droplet
+      - name: Copy config files to Droplet
         run: |
           scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no ./remote_files/test_env/* $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV:/minitwit/
         env: 
           SSH_USER_TEST_ENV: ${{ secrets.SSH_USER_TEST_ENV }}
           SSH_HOST_TEST_ENV: ${{ secrets.SSH_HOST_TEST_ENV }}
 
-      - name: Deploy to server
+      - name: Deploy to test-server
         run: >
           ssh $SSH_USER_TEST_ENV@$SSH_HOST_TEST_ENV
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no


### PR DESCRIPTION
Rename step in PR workflow.
Add step in continuous deployment workflow that copies the configuration files (deploy.sh and compose_stack.yaml) to the production server, so that changes in these files automatically get loaded onto the server and the next deployment will take these changes into account. 